### PR TITLE
build: configure project for exact dependency pinning

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+We welcome contributions to this project! Please follow these guidelines to ensure a smooth development process.
+
+## Development Workflow
+
+[You can add your project's specific development workflow details here, e.g., branching strategy, code style, testing procedures.]
+
+## Managing Dependencies
+
+This project enforces the use of exact versions for all npm dependencies to ensure consistency, stability, and avoid unexpected issues arising from version mismatches or unintended updates.
+
+### Adding New Dependencies
+
+1.  **Configuration for Exact Versions**: The project is configured with an `.npmrc` file containing `save-exact=true`. This means that when you add a new package, npm will automatically save its exact version to `package.json`.
+
+2.  **Installation**: To add a new dependency, simply run:
+    ```bash
+    npm install <package-name>
+    ```
+    Or, for a development dependency:
+    ```bash
+    npm install <package-name> --save-dev
+    ```
+    You do **not** need to add the `--save-exact` flag manually; the `.npmrc` file handles this.
+
+3.  **Verify `package-lock.json`**: After installing a new dependency, `package.json` and `package-lock.json` will be updated. Please ensure these changes are committed along with your code. The `package-lock.json` file is crucial as it records the exact versions of all dependencies and their sub-dependencies.
+
+4.  **Why Exact Versions?**:
+    *   **Reproducibility**: Ensures that every developer and the CI/CD environment installs the exact same version of every package, leading to reproducible builds.
+    *   **Stability**: Protects against accidental upgrades to new minor or patch versions that might introduce bugs or breaking changes.
+    *   **Clarity**: `package.json` directly reflects the specific versions being used, reducing ambiguity.
+
+### Updating Dependencies
+
+If you need to update a dependency, it should be a deliberate action:
+
+1.  Install the new version specifically:
+    ```bash
+    npm install <package-name>@<version>
+    ```
+2.  Test thoroughly after updating.
+3.  Commit the updated `package.json` and `package-lock.json` files.
+
+[Add any other contribution guidelines specific to your project below.]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Dependency Management
+
+This project uses npm (Node Package Manager) and relies on the `package-lock.json` file to ensure that all developers and build environments use the exact same versions of project dependencies. This practice is crucial for maintaining consistency and avoiding "works on my machine" issues.
+
+**Recommended Installation Command:**
+
+For most cases, especially in CI/CD pipelines or when setting up the project for the first time, it is recommended to use:
+
+```bash
+npm ci
+```
+
+This command installs dependencies strictly based on `package-lock.json`, which can be faster and more reliable than `npm install` for ensuring reproducible builds. `npm install` should be used when you intend to update your dependencies or add new ones (which will, in turn, update `package-lock.json` if needed).
+
+**Other Package Managers:**
+
+While `npm` and `package-lock.json` are the primary mechanisms for this project, if you prefer using Yarn, pnpm, or Bun (as mentioned in the "Getting Started" section), these tools also generate and use their own lock files (`yarn.lock`, `pnpm-lock.yaml`, and `bun.lockb`, respectively) to achieve the same goal of pinned, reproducible dependency installations.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.3.2",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "19.1.0",
+        "react-dom": "19.1.0"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "^3",
-        "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
-        "eslint": "^9",
+        "@eslint/eslintrc": "3.3.1",
+        "@tailwindcss/postcss": "4.1.7",
+        "@types/node": "20.17.50",
+        "@types/react": "19.1.5",
+        "@types/react-dom": "19.1.5",
+        "eslint": "9.27.0",
         "eslint-config-next": "15.3.2",
-        "tailwindcss": "^4",
-        "typescript": "^5"
+        "tailwindcss": "4.1.7",
+        "typescript": "5.8.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "next": "15.3.2"
   },
   "devDependencies": {
-    "typescript": "^5",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
-    "eslint": "^9",
+    "typescript": "5.8.3",
+    "@types/node": "20.17.50",
+    "@types/react": "19.1.5",
+    "@types/react-dom": "19.1.5",
+    "@tailwindcss/postcss": "4.1.7",
+    "tailwindcss": "4.1.7",
+    "eslint": "9.27.0",
     "eslint-config-next": "15.3.2",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "3.3.1"
   }
 }


### PR DESCRIPTION
This commit implements stricter dependency pinning for the project:

- Adds `save-exact=true` to a new `.npmrc` file. This ensures that `npm install <package>` will always save the exact version to `package.json`.
- Updates existing dependencies and devDependencies in `package.json` to use exact versions, removing `^` and `~` specifiers. The exact versions were derived from the existing `package-lock.json`.
- Creates a `CONTRIBUTING.md` file with guidelines for managing dependencies, explaining the new `save-exact` behavior and the rationale for pinned versions.
- Updates `README.md` with a "Dependency Management" section, explaining the role of `package-lock.json` and recommending the use of `npm ci` for consistent installations.

These changes ensure that dependency versions are strictly controlled, promoting consistency and stability across all development and CI/CD environments.